### PR TITLE
fix(lint): address lint issues from PR #12

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,6 +20,11 @@ linters:
     - gosec
   exclusions:
     generated: strict
+    rules:
+      - path: 'pkg/scaling/algorithm\.go'
+        text: 'type name will be used as scaling\.(ScalingAlgorithm|ScalingInput|ScalingResult)'
+        linters:
+          - revive
 
 formatters:
   enable:

--- a/pkg/controller/reconciler_test.go
+++ b/pkg/controller/reconciler_test.go
@@ -30,14 +30,14 @@ import (
 
 func TestCalculateDesiredReplicas(t *testing.T) {
 	tests := []struct {
-		name                            string
-		policy                          *kubeaiv1alpha1.AIInferenceAutoscalerPolicy
-		currentReplicas                 int32
-		currentMetrics                  *kubeaiv1alpha1.CurrentMetrics
-		expected                        int32
-		expectedAlgorithm               string
-		expectedRequestedAlgoNotFound   bool
-		expectedRequestedName           string
+		name                          string
+		policy                        *kubeaiv1alpha1.AIInferenceAutoscalerPolicy
+		currentReplicas               int32
+		currentMetrics                *kubeaiv1alpha1.CurrentMetrics
+		expected                      int32
+		expectedAlgorithm             string
+		expectedRequestedAlgoNotFound bool
+		expectedRequestedName         string
 	}{
 		{
 			name: "scale up based on latency",
@@ -53,12 +53,12 @@ func TestCalculateDesiredReplicas(t *testing.T) {
 					},
 				},
 			},
-			currentReplicas:                 2,
-			currentMetrics:                  &kubeaiv1alpha1.CurrentMetrics{LatencyP99Ms: 200},
-			expected:                        4,
-			expectedAlgorithm:               "MaxRatio",
-			expectedRequestedAlgoNotFound:   false,
-			expectedRequestedName:           "",
+			currentReplicas:               2,
+			currentMetrics:                &kubeaiv1alpha1.CurrentMetrics{LatencyP99Ms: 200},
+			expected:                      4,
+			expectedAlgorithm:             "MaxRatio",
+			expectedRequestedAlgoNotFound: false,
+			expectedRequestedName:         "",
 		},
 		{
 			name: "scale up based on GPU utilization",
@@ -74,12 +74,12 @@ func TestCalculateDesiredReplicas(t *testing.T) {
 					},
 				},
 			},
-			currentReplicas:                 2,
-			currentMetrics:                  &kubeaiv1alpha1.CurrentMetrics{GPUUtilizationPercent: 100},
-			expected:                        4,
-			expectedAlgorithm:               "MaxRatio",
-			expectedRequestedAlgoNotFound:   false,
-			expectedRequestedName:           "",
+			currentReplicas:               2,
+			currentMetrics:                &kubeaiv1alpha1.CurrentMetrics{GPUUtilizationPercent: 100},
+			expected:                      4,
+			expectedAlgorithm:             "MaxRatio",
+			expectedRequestedAlgoNotFound: false,
+			expectedRequestedName:         "",
 		},
 		{
 			name: "respect max replicas",
@@ -95,12 +95,12 @@ func TestCalculateDesiredReplicas(t *testing.T) {
 					},
 				},
 			},
-			currentReplicas:                 3,
-			currentMetrics:                  &kubeaiv1alpha1.CurrentMetrics{LatencyP99Ms: 500},
-			expected:                        5,
-			expectedAlgorithm:               "MaxRatio",
-			expectedRequestedAlgoNotFound:   false,
-			expectedRequestedName:           "",
+			currentReplicas:               3,
+			currentMetrics:                &kubeaiv1alpha1.CurrentMetrics{LatencyP99Ms: 500},
+			expected:                      5,
+			expectedAlgorithm:             "MaxRatio",
+			expectedRequestedAlgoNotFound: false,
+			expectedRequestedName:         "",
 		},
 		{
 			name: "respect min replicas",
@@ -116,12 +116,12 @@ func TestCalculateDesiredReplicas(t *testing.T) {
 					},
 				},
 			},
-			currentReplicas:                 1,
-			currentMetrics:                  &kubeaiv1alpha1.CurrentMetrics{LatencyP99Ms: 100},
-			expected:                        2,
-			expectedAlgorithm:               "MaxRatio",
-			expectedRequestedAlgoNotFound:   false,
-			expectedRequestedName:           "",
+			currentReplicas:               1,
+			currentMetrics:                &kubeaiv1alpha1.CurrentMetrics{LatencyP99Ms: 100},
+			expected:                      2,
+			expectedAlgorithm:             "MaxRatio",
+			expectedRequestedAlgoNotFound: false,
+			expectedRequestedName:         "",
 		},
 		{
 			name: "no scaling when at target",
@@ -137,12 +137,12 @@ func TestCalculateDesiredReplicas(t *testing.T) {
 					},
 				},
 			},
-			currentReplicas:                 3,
-			currentMetrics:                  &kubeaiv1alpha1.CurrentMetrics{LatencyP99Ms: 100},
-			expected:                        3,
-			expectedAlgorithm:               "MaxRatio",
-			expectedRequestedAlgoNotFound:   false,
-			expectedRequestedName:           "",
+			currentReplicas:               3,
+			currentMetrics:                &kubeaiv1alpha1.CurrentMetrics{LatencyP99Ms: 100},
+			expected:                      3,
+			expectedAlgorithm:             "MaxRatio",
+			expectedRequestedAlgoNotFound: false,
+			expectedRequestedName:         "",
 		},
 		{
 			name: "use highest ratio from multiple metrics",
@@ -162,12 +162,12 @@ func TestCalculateDesiredReplicas(t *testing.T) {
 					},
 				},
 			},
-			currentReplicas:                 2,
-			currentMetrics:                  &kubeaiv1alpha1.CurrentMetrics{LatencyP99Ms: 150, GPUUtilizationPercent: 150},
-			expected:                        6,
-			expectedAlgorithm:               "MaxRatio",
-			expectedRequestedAlgoNotFound:   false,
-			expectedRequestedName:           "",
+			currentReplicas:               2,
+			currentMetrics:                &kubeaiv1alpha1.CurrentMetrics{LatencyP99Ms: 150, GPUUtilizationPercent: 150},
+			expected:                      6,
+			expectedAlgorithm:             "MaxRatio",
+			expectedRequestedAlgoNotFound: false,
+			expectedRequestedName:         "",
 		},
 		{
 			name: "use AverageRatio algorithm",
@@ -191,12 +191,12 @@ func TestCalculateDesiredReplicas(t *testing.T) {
 					},
 				},
 			},
-			currentReplicas:                 2,
-			currentMetrics:                  &kubeaiv1alpha1.CurrentMetrics{LatencyP99Ms: 200, GPUUtilizationPercent: 100},
-			expected:                        4, // avg of 2.0 and 2.0 = 2.0, 2 * 2.0 = 4
-			expectedAlgorithm:               "AverageRatio",
-			expectedRequestedAlgoNotFound:   false,
-			expectedRequestedName:           "AverageRatio",
+			currentReplicas:               2,
+			currentMetrics:                &kubeaiv1alpha1.CurrentMetrics{LatencyP99Ms: 200, GPUUtilizationPercent: 100},
+			expected:                      4, // avg of 2.0 and 2.0 = 2.0, 2 * 2.0 = 4
+			expectedAlgorithm:             "AverageRatio",
+			expectedRequestedAlgoNotFound: false,
+			expectedRequestedName:         "AverageRatio",
 		},
 		{
 			name: "fallback to MaxRatio for unknown algorithm",
@@ -215,12 +215,12 @@ func TestCalculateDesiredReplicas(t *testing.T) {
 					},
 				},
 			},
-			currentReplicas:                 2,
-			currentMetrics:                  &kubeaiv1alpha1.CurrentMetrics{LatencyP99Ms: 200},
-			expected:                        4,
-			expectedAlgorithm:               "MaxRatio", // Falls back
-			expectedRequestedAlgoNotFound:   true,
-			expectedRequestedName:           "NonExistentAlgorithm",
+			currentReplicas:               2,
+			currentMetrics:                &kubeaiv1alpha1.CurrentMetrics{LatencyP99Ms: 200},
+			expected:                      4,
+			expectedAlgorithm:             "MaxRatio", // Falls back
+			expectedRequestedAlgoNotFound: true,
+			expectedRequestedName:         "NonExistentAlgorithm",
 		},
 	}
 

--- a/pkg/scaling/algorithm.go
+++ b/pkg/scaling/algorithm.go
@@ -82,7 +82,7 @@ func (a *MaxRatioAlgorithm) Name() string {
 }
 
 // ComputeScale implements the ScalingAlgorithm interface
-func (a *MaxRatioAlgorithm) ComputeScale(ctx context.Context, input ScalingInput) (ScalingResult, error) {
+func (a *MaxRatioAlgorithm) ComputeScale(_ context.Context, input ScalingInput) (ScalingResult, error) {
 	tolerance := input.Tolerance
 
 	if len(input.MetricRatios) == 0 {
@@ -192,7 +192,7 @@ func (a *AverageRatioAlgorithm) Name() string {
 }
 
 // ComputeScale implements the ScalingAlgorithm interface
-func (a *AverageRatioAlgorithm) ComputeScale(ctx context.Context, input ScalingInput) (ScalingResult, error) {
+func (a *AverageRatioAlgorithm) ComputeScale(_ context.Context, input ScalingInput) (ScalingResult, error) {
 	tolerance := input.Tolerance
 
 	if len(input.MetricRatios) == 0 {
@@ -307,7 +307,7 @@ func (a *WeightedRatioAlgorithm) SetWeights(weights []float64) {
 }
 
 // ComputeScale implements the ScalingAlgorithm interface
-func (a *WeightedRatioAlgorithm) ComputeScale(ctx context.Context, input ScalingInput) (ScalingResult, error) {
+func (a *WeightedRatioAlgorithm) ComputeScale(_ context.Context, input ScalingInput) (ScalingResult, error) {
 	tolerance := input.Tolerance
 
 	if len(input.MetricRatios) == 0 {

--- a/pkg/scaling/algorithm_test.go
+++ b/pkg/scaling/algorithm_test.go
@@ -320,7 +320,7 @@ func TestScalingAlgorithm_ToleranceFromInput(t *testing.T) {
 	assert.Equal(t, int32(3), result.DesiredReplicas)
 }
 
-func TestScalingAlgorithm_ImplementsInterface(t *testing.T) {
+func TestScalingAlgorithm_ImplementsInterface(_ *testing.T) {
 	// Verify all algorithms implement ScalingAlgorithm
 	var _ ScalingAlgorithm = (*MaxRatioAlgorithm)(nil)
 	var _ ScalingAlgorithm = (*AverageRatioAlgorithm)(nil)

--- a/pkg/scaling/plugin_test.go
+++ b/pkg/scaling/plugin_test.go
@@ -40,7 +40,7 @@ func TestLoadPlugin_InvalidFile(t *testing.T) {
 	tmpDir := t.TempDir()
 	invalidPlugin := filepath.Join(tmpDir, "invalid.so")
 
-	err := os.WriteFile(invalidPlugin, []byte("not a plugin"), 0644)
+	err := os.WriteFile(invalidPlugin, []byte("not a plugin"), 0600) // #nosec G306
 	assert.NoError(t, err)
 
 	_, err = LoadPlugin(invalidPlugin)
@@ -62,7 +62,7 @@ func TestLoadPlugins_NotADirectory(t *testing.T) {
 	tmpDir := t.TempDir()
 	tmpFile := filepath.Join(tmpDir, "notadir")
 
-	err := os.WriteFile(tmpFile, []byte("file"), 0644)
+	err := os.WriteFile(tmpFile, []byte("file"), 0600) // #nosec G306
 	assert.NoError(t, err)
 
 	_, err = LoadPlugins(tmpFile)

--- a/pkg/scaling/registry.go
+++ b/pkg/scaling/registry.go
@@ -41,6 +41,7 @@ func (e ErrAlgorithmAlreadyRegistered) Error() string {
 	return fmt.Sprintf("algorithm already registered: name=%q", e.Name)
 }
 
+// ErrInvalidAlgorithmName is returned when an algorithm name is empty
 type ErrInvalidAlgorithmName struct{}
 
 func (e ErrInvalidAlgorithmName) Error() string {

--- a/pkg/scaling/registry_test.go
+++ b/pkg/scaling/registry_test.go
@@ -34,7 +34,7 @@ func (m *mockAlgorithm) Name() string {
 	return m.name
 }
 
-func (m *mockAlgorithm) ComputeScale(ctx context.Context, input ScalingInput) (ScalingResult, error) {
+func (m *mockAlgorithm) ComputeScale(_ context.Context, input ScalingInput) (ScalingResult, error) {
 	return ScalingResult{
 		DesiredReplicas: input.CurrentReplicas,
 		Reason:          "mock",
@@ -110,9 +110,9 @@ func TestRegistry_Get(t *testing.T) {
 	require.NoError(t, r.Register(algo))
 
 	tests := []struct {
-		name    string
+		name     string
 		algoName string
-		wantErr bool
+		wantErr  bool
 	}{
 		{
 			name:     "get existing algorithm",


### PR DESCRIPTION
## Description

This PR fixes lint issues introduced in PR #12 that are causing CI failures on main branch.

## Changes

- **Fix unused parameter warnings**: Renamed unused  parameters to  in scaling algorithms
- **Fix gosec G306 warnings**: Changed file permissions from 0644 to 0600 in test files
- **Add missing documentation**: Added comment for exported type 
- **Fix goimports formatting**: Ran goimports on affected test files
- **Update golangci-lint config**: Added exclusion rule for intentional stuttering type names in scaling package (ScalingAlgorithm, ScalingInput, ScalingResult)

## Lint Issues Fixed

- ✅ unused-parameter warnings (4 instances)
- ✅ gosec G306 warnings (2 instances)
- ✅ exported type documentation (1 instance)
- ✅ goimports formatting (2 files)
- ✅ revive stuttering type names (3 instances - excluded as intentional)

## Testing

- [x] 0 issues. passes locally with 0 issues
- [x] All existing tests pass

Fixes the failing CI run: https://github.com/pmady/kubeai-autoscaler/actions/runs/21295465464