### PR TITLE
Add unit tests for Prometheus (pkg/metrics) package

### DIFF
--- a/pkg/metrics/prometheus_test.go
+++ b/pkg/metrics/prometheus_test.go
@@ -19,9 +19,14 @@ package metrics
 import (
 	"context"
 	"errors"
+	"fmt"
+	"math"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMockClient(t *testing.T) {
@@ -141,4 +146,454 @@ func TestDefaultQueries(t *testing.T) {
 
 	_, err = mock.GetQueueDepth(ctx, "")
 	assert.NoError(t, err)
+}
+
+// Helper functions for generating Prometheus API responses
+
+func makeVectorResponse(value float64) string {
+	return fmt.Sprintf(`{
+		"status": "success",
+		"data": {
+			"resultType": "vector",
+			"result": [{"metric": {}, "value": [1234567890.123, "%v"]}]
+		}
+	}`, value)
+}
+
+func makeVectorResponseMultiple(values ...float64) string {
+	results := ""
+	for i, v := range values {
+		if i > 0 {
+			results += ", "
+		}
+		results += fmt.Sprintf(`{"metric": {}, "value": [1234567890.123, "%v"]}`, v)
+	}
+	return fmt.Sprintf(`{
+		"status": "success",
+		"data": {
+			"resultType": "vector",
+			"result": [%s]
+		}
+	}`, results)
+}
+
+func makeScalarResponse(value float64) string {
+	return fmt.Sprintf(`{
+		"status": "success",
+		"data": {
+			"resultType": "scalar",
+			"result": [1234567890.123, "%v"]
+		}
+	}`, value)
+}
+
+func makeEmptyVectorResponse() string {
+	return `{
+		"status": "success",
+		"data": {
+			"resultType": "vector",
+			"result": []
+		}
+	}`
+}
+
+func makeErrorResponse(errorType, message string) string {
+	return fmt.Sprintf(`{
+		"status": "error",
+		"errorType": "%s",
+		"error": "%s"
+	}`, errorType, message)
+}
+
+func makeMatrixResponse() string {
+	return `{
+		"status": "success",
+		"data": {
+			"resultType": "matrix",
+			"result": [{"metric": {}, "values": [[1234567890.123, "123.45"]]}]
+		}
+	}`
+}
+
+const floatDelta = 1e-6
+
+// TestPrometheusClient_ImplementsInterface verifies PrometheusClient implements Client interface
+func TestPrometheusClient_ImplementsInterface(t *testing.T) {
+	var _ Client = (*PrometheusClient)(nil)
+}
+
+func TestNewPrometheusClient(t *testing.T) {
+	client, err := NewPrometheusClient("http://localhost:9090")
+	require.NoError(t, err)
+	require.NotNil(t, client)
+	require.NotNil(t, client.api)
+}
+
+func TestPrometheusClient_Query_Success(t *testing.T) {
+	tests := []struct {
+		name           string
+		response       string
+		expectedValue  float64
+	}{
+		{
+			name:          "vector response",
+			response:      makeVectorResponse(123.45),
+			expectedValue: 123.45,
+		},
+		{
+			name:          "scalar response",
+			response:      makeScalarResponse(67.89),
+			expectedValue: 67.89,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(tt.response))
+			}))
+			defer server.Close()
+
+			client, err := NewPrometheusClient(server.URL)
+			require.NoError(t, err)
+
+			value, err := client.Query(context.Background(), "test_query")
+			require.NoError(t, err)
+			assert.InDelta(t, tt.expectedValue, value, floatDelta)
+		})
+	}
+}
+
+func TestPrometheusClient_GetLatencyP99(t *testing.T) {
+	var capturedQuery string
+	expectedValue := 0.150
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Parse form to get query - Prometheus client sends as form data
+		_ = r.ParseForm()
+		capturedQuery = r.FormValue("query")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(makeVectorResponse(expectedValue)))
+	}))
+	defer server.Close()
+
+	client, err := NewPrometheusClient(server.URL)
+	require.NoError(t, err)
+
+	value, err := client.GetLatencyP99(context.Background(), "")
+	require.NoError(t, err)
+	assert.InDelta(t, expectedValue, value, floatDelta)
+
+	// Verify the default query contains expected components
+	assert.Contains(t, capturedQuery, "0.99")
+	assert.Contains(t, capturedQuery, "histogram_quantile")
+	assert.Contains(t, capturedQuery, "inference_request_duration_seconds_bucket")
+}
+
+func TestPrometheusClient_GetLatencyP95(t *testing.T) {
+	var capturedQuery string
+	expectedValue := 0.120
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		capturedQuery = r.FormValue("query")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(makeVectorResponse(expectedValue)))
+	}))
+	defer server.Close()
+
+	client, err := NewPrometheusClient(server.URL)
+	require.NoError(t, err)
+
+	value, err := client.GetLatencyP95(context.Background(), "")
+	require.NoError(t, err)
+	assert.InDelta(t, expectedValue, value, floatDelta)
+
+	// Verify the default query contains expected components
+	assert.Contains(t, capturedQuery, "0.95")
+	assert.Contains(t, capturedQuery, "histogram_quantile")
+	assert.Contains(t, capturedQuery, "inference_request_duration_seconds_bucket")
+}
+
+func TestPrometheusClient_GetGPUUtilization(t *testing.T) {
+	var capturedQuery string
+	expectedValue := 75.5
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		capturedQuery = r.FormValue("query")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(makeVectorResponse(expectedValue)))
+	}))
+	defer server.Close()
+
+	client, err := NewPrometheusClient(server.URL)
+	require.NoError(t, err)
+
+	value, err := client.GetGPUUtilization(context.Background(), "")
+	require.NoError(t, err)
+	assert.InDelta(t, expectedValue, value, floatDelta)
+
+	// Verify the default query contains expected components
+	assert.Contains(t, capturedQuery, "DCGM_FI_DEV_GPU_UTIL")
+	assert.Contains(t, capturedQuery, "avg")
+}
+
+func TestPrometheusClient_GetQueueDepth(t *testing.T) {
+	var capturedQuery string
+	expectedValue := int64(42)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		capturedQuery = r.FormValue("query")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(makeVectorResponse(float64(expectedValue))))
+	}))
+	defer server.Close()
+
+	client, err := NewPrometheusClient(server.URL)
+	require.NoError(t, err)
+
+	value, err := client.GetQueueDepth(context.Background(), "")
+	require.NoError(t, err)
+	assert.Equal(t, expectedValue, value)
+
+	// Verify the default query contains expected components
+	assert.Contains(t, capturedQuery, "inference_request_queue_depth")
+	assert.Contains(t, capturedQuery, "sum")
+}
+
+func TestPrometheusClient_Query_Errors(t *testing.T) {
+	tests := []struct {
+		name               string
+		setupServer        func() *httptest.Server
+		closeBeforeQuery   bool
+		expectedErrContains string
+	}{
+		{
+			name: "connection failure",
+			setupServer: func() *httptest.Server {
+				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(http.StatusOK)
+				}))
+			},
+			closeBeforeQuery:   true,
+		},
+		{
+			name: "HTTP 500 error",
+			setupServer: func() *httptest.Server {
+				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(http.StatusInternalServerError)
+				}))
+			},
+		},
+		{
+			name: "HTTP 400 error with error JSON",
+			setupServer: func() *httptest.Server {
+				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(http.StatusBadRequest)
+					_, _ = w.Write([]byte(makeErrorResponse("bad_data", "invalid query")))
+				}))
+			},
+		},
+		{
+			name: "Prometheus error status",
+			setupServer: func() *httptest.Server {
+				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write([]byte(makeErrorResponse("execution", "query execution error")))
+				}))
+			},
+		},
+		{
+			name: "empty result",
+			setupServer: func() *httptest.Server {
+				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write([]byte(makeEmptyVectorResponse()))
+				}))
+			},
+			expectedErrContains: "no data returned from query:",
+		},
+		{
+			name: "invalid JSON",
+			setupServer: func() *httptest.Server {
+				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write([]byte(`{not-json`))
+				}))
+			},
+		},
+		{
+			name: "unexpected result type (matrix)",
+			setupServer: func() *httptest.Server {
+				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write([]byte(makeMatrixResponse()))
+				}))
+			},
+			expectedErrContains: "unexpected result type:",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := tt.setupServer()
+			serverURL := server.URL
+
+			if tt.closeBeforeQuery {
+				server.Close()
+			} else {
+				defer server.Close()
+			}
+
+			client, err := NewPrometheusClient(serverURL)
+			require.NoError(t, err)
+
+			_, err = client.Query(context.Background(), "test_query")
+			require.Error(t, err)
+			if tt.expectedErrContains != "" {
+				assert.Contains(t, err.Error(), tt.expectedErrContains)
+			}
+		})
+	}
+}
+
+func TestPrometheusClient_GetQueueDepth_Error(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(makeEmptyVectorResponse()))
+	}))
+	defer server.Close()
+
+	client, err := NewPrometheusClient(server.URL)
+	require.NoError(t, err)
+
+	_, err = client.GetQueueDepth(context.Background(), "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no data returned from query:")
+}
+
+func TestPrometheusClient_ContextCancellation(t *testing.T) {
+	started := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		close(started)
+		<-r.Context().Done()
+	}))
+	defer server.Close()
+
+	client, err := NewPrometheusClient(server.URL)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, qErr := client.Query(ctx, "test_query")
+		errCh <- qErr
+	}()
+
+	<-started
+	cancel()
+
+	err = <-errCh
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded),
+		"expected context cancellation error, got %v", err)
+}
+
+func TestPrometheusClient_Query_MultipleSamples(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(makeVectorResponseMultiple(11.11, 22.22)))
+	}))
+	defer server.Close()
+
+	client, err := NewPrometheusClient(server.URL)
+	require.NoError(t, err)
+
+	value, err := client.Query(context.Background(), "test_query")
+	require.NoError(t, err)
+	assert.InDelta(t, 11.11, value, floatDelta)
+}
+
+func TestPrometheusClient_CustomQuery(t *testing.T) {
+	var capturedQuery string
+	customQuery := "custom_metric{label=\"value\"}"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		capturedQuery = r.FormValue("query")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(makeVectorResponse(99.9)))
+	}))
+	defer server.Close()
+
+	client, err := NewPrometheusClient(server.URL)
+	require.NoError(t, err)
+
+	// Test GetLatencyP99 with custom query
+	capturedQuery = ""
+	value, err := client.GetLatencyP99(context.Background(), customQuery)
+	require.NoError(t, err)
+	assert.InDelta(t, 99.9, value, floatDelta)
+	assert.Equal(t, customQuery, capturedQuery)
+
+	// Test GetLatencyP95 with custom query
+	capturedQuery = ""
+	value, err = client.GetLatencyP95(context.Background(), customQuery)
+	require.NoError(t, err)
+	assert.InDelta(t, 99.9, value, floatDelta)
+	assert.Equal(t, customQuery, capturedQuery)
+
+	// Test GetGPUUtilization with custom query
+	capturedQuery = ""
+	value, err = client.GetGPUUtilization(context.Background(), customQuery)
+	require.NoError(t, err)
+	assert.InDelta(t, 99.9, value, floatDelta)
+	assert.Equal(t, customQuery, capturedQuery)
+
+	// Test GetQueueDepth with custom query
+	capturedQuery = ""
+	queueDepth, err := client.GetQueueDepth(context.Background(), customQuery)
+	require.NoError(t, err)
+	assert.Equal(t, int64(99), queueDepth)
+	assert.Equal(t, customQuery, capturedQuery)
+}
+
+func TestPrometheusClient_Query_NonNumericSample(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{
+			"status": "success",
+			"data": {
+				"resultType": "vector",
+				"result": [{"metric": {}, "value": [1234567890.123, "NaN"]}]
+			}
+		}`))
+	}))
+	defer server.Close()
+
+	client, err := NewPrometheusClient(server.URL)
+	require.NoError(t, err)
+
+	value, err := client.Query(context.Background(), "test_query")
+	require.NoError(t, err)
+	assert.True(t, math.IsNaN(value), "expected NaN value, got %v", value)
 }


### PR DESCRIPTION
## Summary

  - Add comprehensive unit tests for `PrometheusClient` using `httptest` to mock the Prometheus HTTP API
  - Previously only `MockClient` was tested; now the real client implementation has full test coverage

  ## Changes

  **Helper Functions:**
  - `makeVectorResponse()` - generates successful vector responses
  - `makeScalarResponse()` - generates scalar responses
  - `makeEmptyVectorResponse()` - generates empty result responses
  - `makeErrorResponse()` - generates Prometheus error responses
  - `makeMatrixResponse()` - generates unexpected matrix type responses
  - `makeVectorResponseMultiple()` - generates multi-sample responses

  **Success Tests:**
  - `TestPrometheusClient_ImplementsInterface` - compile-time interface check
  - `TestNewPrometheusClient` - constructor validation
  - `TestPrometheusClient_Query_Success` - vector and scalar response handling
  - `TestPrometheusClient_GetLatencyP99` - verifies default query and return value
  - `TestPrometheusClient_GetLatencyP95` - verifies default query and return value
  - `TestPrometheusClient_GetGPUUtilization` - verifies default query and return value
  - `TestPrometheusClient_GetQueueDepth` - verifies int64 conversion and default query

  **Error Handling Tests:**
  - Connection failure
  - HTTP 500/400 errors
  - Prometheus error status responses
  - Empty results
  - Invalid JSON
  - Unexpected result types (matrix)

  **Edge Case Tests:**
  - Context cancellation
  - Custom query passthrough
  - Multiple samples (returns first)
  - NaN values

  ## Test Plan

  - [x] `go test ./pkg/metrics/...` - all tests pass
  - [x] `go test -cover ./pkg/metrics/...` - 93.8% coverage (exceeds 80% target)
  - [x] `go vet ./pkg/metrics/...` - no issues

  Closes #2